### PR TITLE
Bug fixes which start multiple clients.

### DIFF
--- a/ansible/holon.yml
+++ b/ansible/holon.yml
@@ -18,7 +18,6 @@
       npeers: "{{ npeers | default(5) }}"
       client_port: "{{ client_port | default(13000) }}"
       disable_post_run: "{{ disable_post_run | default(false) | bool }}"
-      client_uuid_array: []
 
   - name: "Prepare parameter to pass across recipes"
     set_fact:

--- a/ansible/lookup_plugin/niova_ctlrequest.py
+++ b/ansible/lookup_plugin/niova_ctlrequest.py
@@ -83,7 +83,9 @@ def niova_raft_lookup_values(ctlreq_dict, raft_key_list):
     '''
     for key in raft_key_list:
         value = dpath.util.values(raft_dict, key)
-        if value[0] == "":
+        if len(value) == 0:
+            value.append("null")
+        elif value[0] == "":
             value[0] = "null"
         output_key = "/%s/%s" % (os.path.basename(os.path.dirname(key)), os.path.basename(key))
         raft_values_dict[output_key] = value[0]


### PR DESCRIPTION
- For multiple clients CLIENT_PORT was same.
- The CLIENT_PORT should get incremented for each
client started by recipe(s).
- Previously client_uuid_array was maintained in memory,
but that was not getting updated properly.
- Added the code for storing the client_uuid_array in recipe
json file.
- Fixed the issue while looking up raft key in json. If raft key
is not present, return it's value as "null"