### PR TITLE
Corrected the conditions with until statement.

### DIFF
--- a/ansible/basic_leader_election.yml
+++ b/ansible/basic_leader_election.yml
@@ -31,7 +31,7 @@
          stage: "leader-election"
       debug:
         msg: "Waiting for leader election"
-      until: lookup('niova_ctlrequest', 'lookup', Server0UUID, '/raft_root_entry/0/leader-uuid', wantlist=True)| dict2items | map(attribute='value') | list | string != "null"
+      until: lookup('niova_ctlrequest', 'lookup', Server0UUID, '/raft_root_entry/0/leader-uuid', wantlist=True)| dict2items | map(attribute='value') | list | first != "null"
       loop: "{{ range(0, 4) | list }}"
       loop_control:
         pause: 2

--- a/ansible/common/tasks/start_client.yml
+++ b/ansible/common/tasks/start_client.yml
@@ -9,6 +9,6 @@
         msg: "Wait till client bootup completes."
       vars:
         stage: "start-client"
-      until: lookup('niova_ctlrequest', 'lookup', ClientUUID, '/raft_client_root_entry', wantlist=True)| dict2items | map(attribute='value') | list | string != "null"
-      retries: 5
-      delay: 2
+      until: ((lookup('niova_ctlrequest', 'lookup', ClientUUID, '/raft_client_root_entry/0/state', wantlist=True)| dict2items | map(attribute='value') | list | first) != "null")
+      retries: 20
+      delay: 1

--- a/ansible/common/tasks/start_server.yml
+++ b/ansible/common/tasks/start_server.yml
@@ -9,6 +9,6 @@
         msg: "Wait till bootup completes."
       vars:
         stage: "start-server"
-      until: (lookup('niova_ctlrequest', 'lookup', ServerUUID, '/raft_root_entry', wantlist=True)| dict2items | map(attribute='value') | list | string != "null") and (lookup('niova_ctlrequest', 'lookup', ServerUUID, '/raft_root_entry/0/state', wantlist=True)| dict2items | map(attribute='value') | list | string != "booting")
+      until: (lookup('niova_ctlrequest', 'lookup', ServerUUID, '/raft_root_entry', wantlist=True)| dict2items | map(attribute='value') | list | first != "null") and (lookup('niova_ctlrequest', 'lookup', ServerUUID, '/raft_root_entry/0/state', wantlist=True)| dict2items | map(attribute='value') | list | first != "booting")
       retries: 5
-      delay: 2
+      delay: 1


### PR DESCRIPTION
It has been observed that due to incorrectly accessing
the output of lookup plugin in until statement,
the loop was exiting even before condition occurs.