### PR TITLE
ignore_time_event can be copied to input directory as well.

### DIFF
--- a/ansible/basic_ctl_int.yml
+++ b/ansible/basic_ctl_int.yml
@@ -21,6 +21,7 @@
         wait_for_ofile: False
         cmd: "ignore_timer_events@true"
         where: "/raft_net_info/ignore_timer_events"
+        copy_to: "init"
         idle_on: "{{lookup('niova_ctlrequest', 'apply_cmd', Server0UUID, cmd, where, wantlist=True)}}"
       debug:
         msg: "{{ idle_on }}"

--- a/ansible/lookup_plugin/niova_ctlrequest.py
+++ b/ansible/lookup_plugin/niova_ctlrequest.py
@@ -16,6 +16,7 @@ the cmd on the given peer-uuid.
 '''
 def niova_ctlreq_cmd_send(recipe_conf, ctlreq_dict):
     wait_for_ofile = True
+    copy_to = "input"
     operation = ctlreq_dict['operation']
     cmd = ctlreq_dict['cmd']
     where = ctlreq_dict['where']
@@ -31,7 +32,10 @@ def niova_ctlreq_cmd_send(recipe_conf, ctlreq_dict):
     app_uuid = genericcmdobj.generate_uuid()
     inotifyobj = InotifyPath(base_dir, True)
     # For idle_on cmd , input_base would be PRIVATE_INIT.
-    if cmd == "ignore_timer_events@true":
+    if 'copy_to' in ctlreq_dict:
+       copy_to = ctlreq_dict['copy_to']
+
+    if cmd == "ignore_timer_events@true" and copy_to == "init":
         input_base = inotify_input_base.PRIVATE_INIT
 
     if 'wait_for_ofile' in ctlreq_dict:
@@ -184,6 +188,8 @@ def niova_ctlrequest_get_cmdline_input_dict(global_args, local_args):
         ctlreq_cmd_dict['cmd'] = local_args[2]
         ctlreq_cmd_dict['where'] = local_args[3]
         ctlreq_cmd_dict['raft_key'] = "None"
+        if 'copy_to' in global_args['variables']:
+            ctlreq_cmd_dict['copy_to'] = global_args['variables']['copy_to']
 
 
     elif ctlreq_cmd_dict['operation'] == "lookup":


### PR DESCRIPTION
Till now we have been copying cmd to ignore_timer_event in
init directory only.
But recipe should point out where to copy the ctlrequest cmd
depending on the test.
Added new parameter "copy_to" for specifying where to copy,
input or init directory.
By default it will be copied in input directory. But to copy
in init, copy_to variable should be set to "init".