### PR TITLE
Issue #97 Added option for task profiling.

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
 host: localhost
 lookup_plugins = ~/.ansible/plugins/lookup_plugins/:./lookup_plugin
+callback_whitelist = profile_tasks
 # Add log_path if you want to redirect ansible logs to the file.


### PR DESCRIPTION
Enabled profiling the tasks/recipes
by adding "callback_whitelist = profile_tasks" 
in ansible.cfg to get the execution time for each task and recipes.