### PR TITLE
Bug fix in getting the running server UUIDs.

### DIFF
--- a/ansible/common/tasks/get_follower_stats.yml
+++ b/ansible/common/tasks/get_follower_stats.yml
@@ -27,7 +27,7 @@
         process_uuid: "{{ raft_processes[item]['process_uuid'] }}"
       set_fact:
         NRunningPeers: "{{ NRunningPeers + [raft_processes[item]['process_uuid']] }}"
-      when: raft_processes[item]['process_type'] == "server"
+      when: raft_processes[item]['process_type'] == "server" and raft_processes[item]['process_status'] == "running"
       loop: "{{ range(0, raft_processes | length) | list }}"
 
     - name: "{{ recipe_name }}: Get the Leader UUID."

--- a/ansible/common/tasks/get_server_uuid_info.yml
+++ b/ansible/common/tasks/get_server_uuid_info.yml
@@ -27,7 +27,7 @@
         process_uuid: "{{ raft_processes[item]['process_uuid'] }}"
       set_fact:
         NRunningPeers: "{{ NRunningPeers + [raft_processes[item]['process_uuid']] }}"
-      when: raft_processes[item]['process_type'] == "server"
+      when: raft_processes[item]['process_type'] == "server" and raft_processes[item]['process_status'] == "running"
       loop: "{{ range(0, raft_processes | length) | list }}"
 
     - name: "Get the list of all peers"

--- a/ansible/raftprocess.py
+++ b/ansible/raftprocess.py
@@ -105,6 +105,7 @@ class RaftProcess:
 
         #Check if child process exited with error
         if process_popen.poll() is None:
+            self.process_status = "running"
             logging.info("Raft process started successfully")
         else:
             logging.info("Raft process failed to start")
@@ -142,6 +143,7 @@ class RaftProcess:
         To check if process is paused
         '''
         self.Wait_for_process_status("stopped", pid)
+        self.process_status = "paused"
         return 0
 
     '''
@@ -159,6 +161,7 @@ class RaftProcess:
             logging.error("Failed to send CONT signal with error: %s" % os.stderror(e.errno))
             return -1
 
+        self.process_status = "running"
         return 0
 
     '''
@@ -175,4 +178,6 @@ class RaftProcess:
         except subprocess.SubprocessError as e:
             logging.error("Failed to send kill signal with error: %s" % os.stderror(e.errno))
             return -1
+
+        self.process_status = "killed"
         return 0


### PR DESCRIPTION
In the commong tasks get_follower_stats and
get_server_uuid_info, it finds out the running
server UUIDs by extracting recipe json file.
But there could be paused server process information
in the json file as well.
Added the filter to look for processes with
process_status = "running"