### PR TITLE
Allow holon recipes to run through niova repo.

### DIFF
--- a/ansible/holon.yml
+++ b/ansible/holon.yml
@@ -85,4 +85,4 @@
 - import_playbook: "post_run.yml"
   vars:
     recipe_params: "{{ ClusterParams }}"
-  when: disable_post_run == "False" or disable_post_run == "false" or disable_post_run == false
+    recipe_result: "{{ terminate_recipe }}"

--- a/ansible/post_run.yml
+++ b/ansible/post_run.yml
@@ -2,6 +2,16 @@
   hosts: localhost
 
   tasks:
+
+  - name: "Check if recipe failed and post_run is disabled"
+    debug:
+      msg: "Check the recipe execution status"
+    failed_when: recipe_result == True and disable_post_run == True
+
+  - name: "Exit now as post run is disabled"
+    meta: end_play
+    when: disable_post_run == "True" or disable_post_run == "true" or disable_post_run == True
+
   - name: "Get the json path"
     set_fact:
         base_dir="{{ recipe_params['base_dir']}}"
@@ -30,3 +40,8 @@
     set_fact:
        kill_peer0="{{lookup('niova_raftprocess', 'kill', peer_uuid[item], wantlist=True)}}"
     loop: "{{ range(0, running_npeers| int)| list}}"
+
+  - name: "Check status post run"
+    debug:
+      msg: "If recipe was rescued for post run, make sure we return error"
+    failed_when: recipe_result == True

--- a/ansible/raftprocess.py
+++ b/ansible/raftprocess.py
@@ -24,7 +24,6 @@ class RaftProcess:
     process_status = ''
     process_popen = {}
     process_backend_type = ''
-    binary_path='/home/pauln/raft-builds/latest/raft-server'
     process_pid = 0
 
     '''
@@ -66,16 +65,25 @@ class RaftProcess:
     def start_process(self, raft_uuid, peer_uuid, base_dir):
 
         logging.warning("Starting uuid: %s, cluster_type %s" % (peer_uuid, self.process_backend_type))
+
+        # If user has passed any specific path to use for raft binaries
+        binary_dir = os.getenv('NIOVA_BIN_PATH')
+        logging.warning("raft binary path is: %s" % binary_dir)
+
+        # Otherwise use the default path
+        if binary_dir == None:
+            binary_dir = "/home/pauln/raft-builds/latest"
+
         if self.process_backend_type == "pumicedb":
             if self.process_type == "server":
-                bin_path = '/home/pauln/raft-builds/latest/pumicedb-server-test'
+                bin_path = '%s/pumicedb-server-test' % binary_dir
             else:
-                bin_path = '/home/pauln/raft-builds/latest/pumicedb-client-test'
+                bin_path = '%s/pumicedb-client-test' % binary_dir
         else:
             if self.process_type == "server":
-                bin_path = '/home/pauln/raft-builds/latest/raft-server'
+                bin_path = '%s/raft-server' % binary_dir
             else:
-                bin_path = '/home/pauln/raft-builds/latest/raft-client'
+                bin_path = '%s/raft-client' % binary_dir
 
 
         '''


### PR DESCRIPTION
1. With block and rescue changes made, the failed
status was getting set to zero. But its important
to use block/rescue plus return error code as well
when recipe fails. Added the changes to make sure
post-run gets run even when recipe fails AND error
code is return on failure.

2. Added new env variable to specify niova binary
path. By default its using /home/pauln/raft-build
path.