### PR TITLE
Reverted the commit: 88c243c80bd58f620fa30185395e91923f008137

### DIFF
--- a/recipes/promoting_the_most_qualified_peer_to_lead_multi_peer_recovery.yml
+++ b/recipes/promoting_the_most_qualified_peer_to_lead_multi_peer_recovery.yml
@@ -467,9 +467,9 @@
           - "Verifying all values after electing new leader {{ collect_all_values }}."
       no_log: True
       failed_when: >
-        (collect_all_values['/0/last-applied'] < ((initial_commit_idx | int) + (nwrites | int) + 1)) or
-        (collect_all_values['/0/commit-idx'] < ((initial_commit_idx | int) + (nwrites | int) + 1)) or
-        (collect_all_values['/0/sync-entry-idx'] < ((initial_commit_idx | int) + (nwrites | int) + 1)) or
+        (collect_all_values['/0/last-applied'] != ((initial_commit_idx | int) + (nwrites | int) + 1)) or
+        (collect_all_values['/0/commit-idx'] != ((initial_commit_idx | int) + (nwrites | int) + 1)) or
+        (collect_all_values['/0/sync-entry-idx'] != ((initial_commit_idx | int) + (nwrites | int) + 1)) or
         (collect_all_values['/0/term'] < (initial_term | int))
       
     - name: "{{ recipe_name }}: Verify last-applied-cumulative-crc and sync-entry-crc is same on all peers."


### PR DESCRIPTION
In the previous commit changes were added to allow
multiple unintentional election to happen in
promoting_the_most_qualified_peer_to_lead_multi_peer_recovery.
The recipes should not allow this behavior, so reverting
the change after discussing with Paul.