### PR TITLE
Made a correction in recipe for passing fault injection name to common task 'set_fault_injection_on_all_followers_and_verify'.

### DIFF
--- a/recipes/completing_an_uncommitted_write_following_a_reboot.yml
+++ b/recipes/completing_an_uncommitted_write_following_a_reboot.yml
@@ -134,6 +134,7 @@
         tasks_from: set_fault_injection_on_all_followers_and_verify
       vars:
         ServerUUID: "{{ FollowerUUIDs[item] }}"
+        fault_injection_name: "raft_follower_ignores_non_hb_AE_request"
       loop: "{{ range(0, FollowerUUIDs | length) | list }}"
 
     - name: "{{ recipe_name }}: Start client process."


### PR DESCRIPTION
- Uses common task 'set_fault_injection_on_all_followers_and_verify' from branch 'rebuild_by_committee'.