### PR TITLE
Fix covid CI failure

### DIFF
--- a/lookup_plugin/app_cmd.py
+++ b/lookup_plugin/app_cmd.py
@@ -55,7 +55,11 @@ class LookupModule(LookupBase):
             bin_path = '%s/foodpalaceappclient' % binary_dir
 
         ctlsvc_path = "%s/configs" % base_dir
-        inotifyobj = InotifyPath(base_dir, True)
+       
+        get_process_type = ''
+        lookout_uuid = ''
+
+        inotifyobj = InotifyPath(base_dir, True, get_process_type, lookout_uuid)
         inotifyobj.export_ctlsvc_path(ctlsvc_path)
 
         #start client process and pass the cmd.


### PR DESCRIPTION
inotify object needs 2 extra paramters get_process_type and lookout_uuid
to be passed when we call inotify.