### PR TITLE
Added task to wait untill leader-viable=false

### DIFF
--- a/recipes/pmdb_client_error_demonstration2.yml
+++ b/recipes/pmdb_client_error_demonstration2.yml
@@ -201,7 +201,7 @@
       vars:
          stage: "wait_leader_viableFalse"
       debug:
-        msg: "Waiting for leader viable=false and leader-alive-cnt=0"
+        msg: "Waiting for leader viable=false"
       until: lookup('niova_ctlrequest', 'lookup', client_uuid.stdout, '/raft_client_root_entry/0/leader-viable', wantlist=True) | dict2items | map(attribute='value') | list | first == "false"
       retries: 30
       delay: 1


### PR DESCRIPTION
in one of the CI failure issue, after setting leader timeout to 30
sec then also client was seeing leader-viable as true and
leader-alive-cnt>0.
actual value should be /raft_client_root_entry/leader-viable : false
/raft_client_root_entry/leader-alive-cnt : 0