### PR TITLE
fix the generator number recipe, by extracting the correct parameters from the filename

### DIFF
--- a/lookup_plugin/s3_handler.py
+++ b/lookup_plugin/s3_handler.py
@@ -866,9 +866,8 @@ def copy_DBI_file_generatorNum(cluster_params, dirName, chunk):
         # Select a random file from the list
         random_file = random.choice(file_list)
         filename_parts = random_file.split(".")
-        # Extract the 3rd last element after the dots
+        # Extract the 2nd last element after the dots
         third_last_element = filename_parts[-2]
-        print(third_last_element)
         uuid = filename_parts[3]
         # create dbo file with new uuid
         result = search_files_by_string(dbo_input_path, uuid)

--- a/lookup_plugin/s3_handler.py
+++ b/lookup_plugin/s3_handler.py
@@ -867,8 +867,9 @@ def copy_DBI_file_generatorNum(cluster_params, dirName, chunk):
         random_file = random.choice(file_list)
         filename_parts = random_file.split(".")
         # Extract the 3rd last element after the dots
-        third_last_element = filename_parts[-3]
-        uuid = filename_parts[2]
+        third_last_element = filename_parts[-2]
+        print(third_last_element)
+        uuid = filename_parts[3]
         # create dbo file with new uuid
         result = search_files_by_string(dbo_input_path, uuid)
 
@@ -876,8 +877,8 @@ def copy_DBI_file_generatorNum(cluster_params, dirName, chunk):
         new_third_last_element = str(int(third_last_element) + 1)
 
         # Update the filename with the incremented element
-        filename_parts[-3] = new_third_last_element
-        filename_parts[2] = result
+        filename_parts[-2] = new_third_last_element
+        filename_parts[3] = result
         new_filename = ".".join(filename_parts)
         # Full path for the copied and renamed file
         source_file_path = os.path.join(dbi_input_path, random_file)


### PR DESCRIPTION
- This branch has the fix for generator number recipe failure with the new dbi naming format 
- Earlier the uuid was the 2 field in the file name, now it's third parameter as set sequence numbers are moved ahead of it
- The generation number is the last second field instead of last third field