### PR TITLE
Made changes in delete half dbis method

### DIFF
--- a/lookup_plugin/obj_storage.py
+++ b/lookup_plugin/obj_storage.py
@@ -132,7 +132,7 @@ class s3_operations:
         dbi_path = os.path.join(self.base_path, "gc-download")
         # Print half of the lines
         for file in half_lines:
-           if os.path.basename(file) == "solutionArray":
+           if "solutionArray" in os.path.basename(file):
                continue 
            obj = os.path.join(dbi_path, file)
            os.remove(obj)


### PR DESCRIPTION
	with the new ss changes solution array file
	stores the ss sequence value also, because of this
	change we were unable to identify the solutionArray
	files in delete_half_dbis method. So made changes to
	fix it.