### PR TITLE
Exclude leader-to-be from fi list

### DIFF
--- a/pumicedb_recipes/promoting_the_most_qualified_peer_to_lead_multi_peer_recovery.yml
+++ b/pumicedb_recipes/promoting_the_most_qualified_peer_to_lead_multi_peer_recovery.yml
@@ -270,7 +270,7 @@
         alive_followers: "{{ FollowerUUIDs | difference(Promoting_Selected_Followers) }}"
         leader_to_be: "{{ alive_followers[0] }}"
         pmqp_leader_uuid: "{{ LeaderUUID['/0/leader-uuid'] }}"
-        nalive_follower: "{{ alive_followers | difference(leader_to_be) }}"
+        nalive_follower: "{{ alive_followers | difference([leader_to_be]) }}"
       set_fact:
         No_of_Fi: "{{ no_of_fi + nalive_follower + [pmqp_leader_uuid] }}"
 


### PR DESCRIPTION
fix: exclude leader-to-be from fault injection list

In the promoting_qualified_peer_to_lead recipe, the selected leader-to-be was mistakenly included in the list of peers for fault injection. 