### PR TITLE
Reduce timeouts period in recipes 

### DIFF
--- a/lease_recipes/lease_get_lease_on_already_expired_lease.yml
+++ b/lease_recipes/lease_get_lease_on_already_expired_lease.yml
@@ -25,9 +25,9 @@
       failed_when:
          (app_type != "lease")
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState is expired."
       include_role:
@@ -108,9 +108,9 @@
          (wr_response['TTL'] <= 0) or
          (wr_response['LeaseState'] != GRANTED)
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState is expired."
       include_role:

--- a/lease_recipes/lease_granted_to_only_one_client_at_a_time.yml
+++ b/lease_recipes/lease_granted_to_only_one_client_at_a_time.yml
@@ -117,9 +117,9 @@
       failed_when: >
          (wr_response['LeaseState'] != INVALID)
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState is expired for clientUUID 1."
       include_role:

--- a/lease_recipes/lease_validate_after_expired_lease_granted_to_another_client.yml
+++ b/lease_recipes/lease_validate_after_expired_lease_granted_to_another_client.yml
@@ -68,9 +68,9 @@
         (getLeaseOps[item]['output_data'][0]['LeaseRes']['LeaseState'] != GRANTED)
       loop: "{{ range(0, no_of_leases) | list }}"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_after_expiry.yml
+++ b/lease_recipes/lease_validate_after_expiry.yml
@@ -57,9 +57,9 @@
         (getLeaseOps[item]['output_data'][0]['LeaseRes']['LeaseState'] != GRANTED)
       loop: "{{ range(0, no_of_leases) | list }}"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_after_expiry_after_cluster_reboot.yml
+++ b/lease_recipes/lease_validate_after_expiry_after_cluster_reboot.yml
@@ -71,9 +71,9 @@
          msg:  "{{ lookup('niova_raftprocess', 'start', NRunningPeers[item], wantlist=True) }}"
       loop: "{{ range(0, NRunningPeers | length) | list }}"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_after_refresh_on_expired_lease_from_another_client.yml
+++ b/lease_recipes/lease_validate_after_refresh_on_expired_lease_from_another_client.yml
@@ -68,9 +68,9 @@
         (getLeaseOps[item]['output_data'][0]['LeaseRes']['LeaseState'] != GRANTED)
       loop: "{{ range(0, no_of_leases) | list }}"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_after_refresh_on_expired_lease_from_same_client.yml
+++ b/lease_recipes/lease_validate_after_refresh_on_expired_lease_from_same_client.yml
@@ -26,9 +26,9 @@
       failed_when:
          (app_type != "lease")
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_as_expired_after_leader_kill.yml
+++ b/lease_recipes/lease_validate_as_expired_after_leader_kill.yml
@@ -74,9 +74,9 @@
         (getLeaseOps[item]['output_data'][0]['LeaseRes']['LeaseState'] != GRANTED)
       loop: "{{ range(0, no_of_leases) | list }}"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait untill leaseState of all leases is expired."
       include_role:

--- a/lease_recipes/lease_validate_for_stale_lease_removal_in_progress.yml
+++ b/lease_recipes/lease_validate_for_stale_lease_removal_in_progress.yml
@@ -139,9 +139,9 @@
         ServerUUID: "{{ LeaderUUID['/0/leader-uuid'] }}"
         fault_injection_name: "raft_leader_ignore_direct_req"
 
-    - name: "{{ recipe_name }}: Pause for 60 sec so that lease gets expired."
+    - name: "{{ recipe_name }}: Pause for 5 sec so that lease gets expired."
       pause:
-         seconds: 60
+         seconds: 5
 
     - name: "{{ recipe_name }}: Wait until leaseState of all leases should complete."
       include_role:


### PR DESCRIPTION
In order to combact the cancellation of workflows for running beyond 30mins. We will be reducing the timeout in the recipes.