### PR TITLE
Add scrubber CRC corruption detection and scrub/merge fence recipes

### DIFF
--- a/ctlrequest.py
+++ b/ctlrequest.py
@@ -134,14 +134,14 @@ class CtlRequest:
                 break
             time_global.sleep(0.005)
 
-    def Wait_for_outfile(self, can_fail):
+    def Wait_for_outfile(self, can_fail, timeout_sec=3):
         '''
         Wait for outfile creation.
         Timeout is added to wait for outfile creation till the specified time.
         '''
         rc = 0
         try:
-            func_timeout(60, self.check_for_outfile_creation, args=())
+            func_timeout(timeout_sec, self.check_for_outfile_creation, args=())
         except FunctionTimedOut:
             if can_fail == False:
                 logging.error("Error : timeout occur for outfile creation : %s" % self.output_fpath)

--- a/nisd_recipes/nisd_crc_corruption_detection.yml
+++ b/nisd_recipes/nisd_crc_corruption_detection.yml
@@ -1,0 +1,133 @@
+- name: "nisd_crc_corruption_detection"
+  hosts: localhost
+  connection: local
+  vars:
+    recipe_name: "nisd_crc_corruption_detection"
+    niova_bin: "{{ lookup('env', 'NIOVA_BIN_PATH') }}"
+    img_file: "/tmp/niova_crc_test.img"
+
+  tasks:
+  - block:
+     - name: "{{ recipe_name }}: Generate NISD UUID"
+       shell: "/usr/bin/uuid"
+       register: nisd_uuid_out
+
+     - name: "{{ recipe_name }}: Set get_nisd"
+       set_fact:
+         get_nisd: "{{ nisd_uuid_out.stdout }}"
+
+     - name: "{{ recipe_name }}: Generate vdev UUID"
+       shell: "/usr/bin/uuid"
+       register: vdev_uuid
+
+     - name: "{{ recipe_name }}: Generate client UUID"
+       shell: "/usr/bin/uuid"
+       register: client_uuid
+
+     - name: "{{ recipe_name }}: Create sparse image file"
+       command: "truncate -s 64G {{ img_file }}"
+
+     - name: "{{ recipe_name }}: Initialize NISD device"
+       command: "{{ niova_bin }}/niova-block-ctl -d {{ img_file }} -f -i -u {{ get_nisd }}"
+
+     - name: "{{ recipe_name }}: Start NISD daemon"
+       shell: >
+         {{ niova_bin }}/nisd -d {{ img_file }} -u {{ get_nisd }}
+         >> {{ ClusterParams.base_dir }}/{{ ClusterParams.raft_uuid }}/nisd_{{ get_nisd }}_log.txt 2>&1
+       environment:
+         NIOVA_INOTIFY_BASE_PATH: "{{ ClusterParams.base_dir }}/{{ ClusterParams.raft_uuid }}/nisd-interface"
+         NIOVA_BLOCK_SOCK_PATH: "/tmp/.niova/{{ get_nisd }}"
+       async: 3600
+       poll: 0
+
+     - name: "{{ recipe_name }}: Wait for NISD to report 'running'"
+       vars:
+         lookout_uuid: ""
+       debug:
+         msg: "Polling NISD for running status..."
+       until: lookup('niova_ctlrequest', 'lookup', get_nisd, '/nisd_root_entry/0/status', 'nisd', lookout_uuid) | dict2items | map(attribute='value') | list | first == "running"
+       retries: 20
+       delay: 2
+
+     - name: "{{ recipe_name }}: Enable corrupt_crc_on_write fault injection"
+       vars:
+         cmd: "enabled@true"
+         where: "/fault_injection_points/name@corrupt_crc_on_write"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Perform writes with CRC corruption enabled"
+       vars:
+         input_param: {
+                 'nisd_uuid_to_write' : 'unix:{{ get_nisd }}',
+                 'vdev' : '{{ vdev_uuid.stdout }}',
+                 'read_operation_ratio_percentage' : '0',
+                 'random_seed' : '1',
+                 'client_uuid' : '{{ client_uuid.stdout }}',
+                 'request_size_in_bytes' : '64',
+                 'queue_depth' : '1',
+                 'num_ops' : '500',
+                 'integrity_check' : False,
+                 'sequential_writes' : False,
+                 'blocking_process' : False
+                 }
+       debug:
+         msg: "{{ lookup('nisd_handler', 'niova-block-test', input_param) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Extract corrupted vblk IDs from NISD log"
+       shell: |
+         grep -oP 'FAULT_INJECT\(corrupt_crc_on_write\): corrupted CRC for vblk=\K\d+' {{ ClusterParams.base_dir }}/{{ ClusterParams.raft_uuid }}/nisd_{{ get_nisd }}_log.txt | sort -n
+       register: logged_vblks_raw
+       changed_when: false
+
+     - name: "{{ recipe_name }}: Set logged vblk IDs fact"
+       set_fact:
+         logged_vblk_ids: "{{ logged_vblks_raw.stdout_lines | map('int') | list | sort }}"
+
+     - name: "{{ recipe_name }}: Launch scrub on the chunk"
+       vars:
+         cmd: "scrub-status@start"
+         where: "/nisd_chunks/vdev-uuid@{{ vdev_uuid.stdout }}"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Poll for scrub completion"
+       vars:
+         lookout_uuid: ""
+       debug:
+         msg: "Waiting for scrub to complete..."
+       until: lookup('niova_ctlrequest', 'lookup', get_nisd, '/nisd_chunks/0/scrub-status', 'nisd', lookout_uuid) | dict2items | map(attribute='value') | list | first == "inactive"
+       retries: 20
+       delay: 2
+
+     - name: "{{ recipe_name }}: Verify scrubber detected corrupted CRC"
+       vars:
+         lookout_uuid: ""
+         scrub_data: "{{ lookup('niova_ctlrequest', 'lookup', get_nisd, ['/chunk_scrub/completed'], 'nisd', lookout_uuid) }}"
+         total_csum_mismatches: "{{ scrub_data['/chunk_scrub/completed'] | map(attribute='csum-mismatches') | map('int') | sum }}"
+         scrubber_vblk_ids: "{{ scrub_data['/chunk_scrub/completed'] | map(attribute='mismatch-vblks') | flatten | map(attribute='vblk-id') | map('int') | list | sort }}"
+       assert:
+         that:
+           - total_csum_mismatches | int == 1
+           - scrubber_vblk_ids == logged_vblk_ids
+         fail_msg: "TEST FAILED: scrubber vblks {{ scrubber_vblk_ids }} do not match logged vblks {{ logged_vblk_ids }}."
+         success_msg: "TEST PASSED: scrubber detected {{ total_csum_mismatches }} csum-mismatch(es)."
+
+    rescue:
+     - name: "Recipe: {{ recipe_name }} failed"
+       set_fact:
+         terminate_recipe: true
+
+    always:
+     - name: "{{ recipe_name }}: Terminate NISD"
+       shell: "pkill -15 -f '[n]isd -d {{ img_file }}' || true"
+
+     - name: "{{ recipe_name }}: Remove image file"
+       file:
+         path: "{{ img_file }}"
+         state: absent

--- a/nisd_recipes/nisd_scrub_merge_fence.yml
+++ b/nisd_recipes/nisd_scrub_merge_fence.yml
@@ -1,0 +1,142 @@
+- name: "nisd_scrub_merge_fence"
+  hosts: localhost
+  connection: local
+  vars:
+    recipe_name: "nisd_scrub_merge_fence"
+    niova_bin: "{{ lookup('env', 'NIOVA_BIN_PATH') }}"
+    img_file: "/tmp/niova_fence_test.img"
+
+  tasks:
+  - block:
+     - name: "{{ recipe_name }}: Generate NISD UUID"
+       shell: "/usr/bin/uuid"
+       register: nisd_uuid_out
+
+     - name: "{{ recipe_name }}: Set get_nisd"
+       set_fact:
+         get_nisd: "{{ nisd_uuid_out.stdout }}"
+
+     - name: "{{ recipe_name }}: Generate vdev UUID"
+       shell: "/usr/bin/uuid"
+       register: vdev_uuid
+
+     - name: "{{ recipe_name }}: Generate client UUID"
+       shell: "/usr/bin/uuid"
+       register: client_uuid
+
+     - name: "{{ recipe_name }}: Create sparse image file"
+       command: "truncate -s 64G {{ img_file }}"
+
+     - name: "{{ recipe_name }}: Initialize NISD device"
+       command: "{{ niova_bin }}/niova-block-ctl -d {{ img_file }} -f -i -u {{ get_nisd }}"
+
+     - name: "{{ recipe_name }}: Start NISD daemon"
+       shell: "{{ niova_bin }}/nisd -d {{ img_file }} -u {{ get_nisd }}"
+       environment:
+         NIOVA_INOTIFY_BASE_PATH: "{{ ClusterParams.base_dir }}/{{ ClusterParams.raft_uuid }}/nisd-interface"
+         NIOVA_BLOCK_SOCK_PATH: "/tmp/.niova/{{ get_nisd }}"
+       async: 3600
+       poll: 0
+
+     - name: "{{ recipe_name }}: Wait for NISD to report 'running'"
+       vars:
+         lookout_uuid: ""
+       debug:
+         msg: "Polling NISD for running status..."
+       until: lookup('niova_ctlrequest', 'lookup', get_nisd, '/nisd_root_entry/0/status', 'nisd', lookout_uuid) | dict2items | map(attribute='value') | list | first == "running"
+       retries: 20
+       delay: 2
+
+     - name: "{{ recipe_name }}: Perform initial writes"
+       vars:
+         input_param: {
+                 'nisd_uuid_to_write' : 'unix:{{ get_nisd }}',
+                 'vdev' : '{{ vdev_uuid.stdout }}',
+                 'read_operation_ratio_percentage' : '0',
+                 'random_seed' : '1',
+                 'client_uuid' : '{{ client_uuid.stdout }}',
+                 'request_size_in_bytes' : '64',
+                 'queue_depth' : '1',
+                 'num_ops' : '500',
+                 'integrity_check' : False,
+                 'sequential_writes' : False,
+                 'blocking_process' : False
+                 }
+       debug:
+         msg: "{{ lookup('nisd_handler', 'niova-block-test', input_param) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Activate scrub_yield fault injection"
+       vars:
+         cmd: "enabled@true"
+         where: "/fault_injection_points/name@scrub_yield"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Launch scrub"
+       vars:
+         cmd: "scrub-status@start"
+         where: "/nisd_chunks/vdev-uuid@{{ vdev_uuid.stdout }}"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Launch merge (triggers fence)"
+       vars:
+         cmd: "merge-shallow-status@start"
+         where: "/nisd_chunks/vdev-uuid@{{ vdev_uuid.stdout }}"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Resume scrub"
+       vars:
+         cmd: "submit-scrub-yield@start"
+         where: "/nisd_chunks/vdev-uuid@{{ vdev_uuid.stdout }}"
+         lookout_uuid: ""
+       debug:
+         msg: "{{ lookup('niova_ctlrequest', 'apply_cmd', get_nisd, cmd, where, 'nisd', lookout_uuid) }}"
+       no_log: true
+
+     - name: "{{ recipe_name }}: Poll for scrub completion"
+       vars:
+         lookout_uuid: ""
+       debug:
+         msg: "Waiting for scrub to complete..."
+       until: lookup('niova_ctlrequest', 'lookup', get_nisd, '/nisd_chunks/0/scrub-status', 'nisd', lookout_uuid) | dict2items | map(attribute='value') | list | first == "inactive"
+       retries: 20
+       delay: 2
+
+     - name: "{{ recipe_name }}: Verify fencing logic triggered for full compaction"
+       vars:
+         lookout_uuid: ""
+         merge_root: "{{ lookup('niova_ctlrequest', 'lookup', get_nisd, ['/mb_merge_root_entry'], 'nisd', lookout_uuid) }}"
+         full_comp_fence: >-
+           {{
+             (merge_root['//mb_merge_root_entry']
+             | selectattr('mode', 'equalto', 'full-compaction')
+             | first)['merge-fence'] | default(0)
+           }}
+       assert:
+         that:
+           - full_comp_fence | int > 0
+         fail_msg: "TEST FAILED: Fence logic did not trigger."
+         success_msg: "TEST PASSED: Fence triggered successfully."
+
+    rescue:
+     - name: "Recipe: {{ recipe_name }} failed"
+       set_fact:
+         terminate_recipe: true
+
+    always:
+     - name: "{{ recipe_name }}: Terminate NISD"
+       shell: "pkill -15 -f '[n]isd -d {{ img_file }}' || true"
+
+     - name: "{{ recipe_name }}: Remove image file"
+       file:
+         path: "{{ img_file }}"
+         state: absent


### PR DESCRIPTION
`nisd_crc_corruption_detectio`n: Injects bad CRCs during writes via corrupt_crc_on_write fault injection, then verifies the scrubber's reported csum-mismatches and mismatch vblk IDs exactly match what was logged by nisd.

`nisd_scrub_merge_fence`: Uses scrub_yield to pause a scrub mid-flight, triggers a merge on the same chunk to force the fence path, then resumes the scrub and asserts the full-compaction merge-fence counter is non-zero.

Both also verify the integrity of the data/CRCs that are supposed to correspond.

Also included:  timeout reduced from 60s to 3s for ctl request outfile check. Before, if NISD wasn't ready at first check it would wait 60s before checking for `"status" : running` again.